### PR TITLE
This PR adds two examples using the DQ_CoppeliaSimInterfaceZMQ interface

### DIFF
--- a/coppeliasim/general/README.md
+++ b/coppeliasim/general/README.md
@@ -1,0 +1,8 @@
+
+# General examples using CoppeliaSim
+
+1. Open the DQ_Robotics_lab.ttt scene in CoppeliaSim
+
+![image](https://github.com/user-attachments/assets/92eaba7c-2d6a-4cd3-9a84-d3fedc74ac9e)
+
+2. Ensure you have installed or defined the path for the DQ Robotics library, and the [ZMQ client for Matlab](https://github.com/CoppeliaRobotics/zmqRemoteApi/tree/coppeliasim-v4.7.0-rev2/clients/matlab)

--- a/coppeliasim/general/README.md
+++ b/coppeliasim/general/README.md
@@ -1,6 +1,11 @@
 
 # General examples using CoppeliaSim
 
+| Example  | Description |
+| ------------- | ------------- |
+| stepping_mode_test.m  | Test the stepping (formerly known as synchronous mode) using a free fall experiment |
+| basic_commands  | Test the basic commands of the class using different objects and robots |
+
 1. Open the DQ_Robotics_lab.ttt scene in CoppeliaSim
 
 ![image](https://github.com/user-attachments/assets/92eaba7c-2d6a-4cd3-9a84-d3fedc74ac9e)

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -25,8 +25,8 @@
 %
 % Note:
 %
-% Open the DQ_Robotics_lab.ttt scene in CoppeliaSim before running this
-% script.
+% Open the DQ_Robotics_lab.ttt scene (https://github.com/dqrobotics/coppeliasim-scenes) 
+% in CoppeliaSim before running this script.
 
 
 clear;
@@ -91,9 +91,7 @@ try
 
         % Set the torque of the Dummy Robot
         torque = sin(2*pi*freq*t);
-        cs.set_joint_torques({'Revolute_joint'}, torque);
-        torque_read = cs.get_joint_torques({'Revolute_joint'});
-        vel_read = cs.get_joint_velocities({'Revolute_joint'});
+        cs.set_joint_target_forces({'Revolute_joint'}, torque);
         
 
         % Set the target velocities of the Pioneer wheels
@@ -103,17 +101,28 @@ try
 
         % Trigger a simulation step in CoppeliaSim
         cs.trigger_next_simulation_step();    
-        
 
-        % Save data to compare the reference and read torques
+        % Read the joint force after perform a the simulation step
+        torque_read = cs.get_joint_forces({'Revolute_joint'});
+
+        % Save data to compare the target and read forces
         torque_log(i+1) = torque;
         torque_read_log(i+1) = torque_read;
     end
 
     cs.stop_simulation(); % Stop the simulation
-    plot(torque_log, 'b');
+
+
+    h1 = figure;
+    set(h1, 'DefaultTextFontSize', 15);
+    set(h1, 'DefaultAxesFontSize', 15);
+    plot(torque_log, 'b', 'LineWidth', 2);
     hold on
-    plot(torque_read_log, 'r')
+    plot(torque_read_log, ':r', 'LineWidth', 2)
+    legend('target force', 'measured force');
+    fig = gcf;
+    fig.Color = [1 1 1];
+    box('off');
 
 catch ME
 

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -89,9 +89,12 @@ try
         target_velocity = 2*pi*freq*cos(2*pi*freq*t);
         cs.set_joint_target_velocities({'Franka/joint'}, target_velocity);
 
-        % Set the torque of the fifth joint of the Franka Emika Panda
+        % Set the torque of the Dummy Robot
         torque = sin(2*pi*freq*t);
-        cs.set_joint_torques({'Franka/link5_resp/joint'}, torque);
+        cs.set_joint_torques({'Revolute_joint'}, torque);
+        torque_read = cs.get_joint_torques({'Revolute_joint'});
+        vel_read = cs.get_joint_velocities({'Revolute_joint'});
+        
 
         % Set the target velocities of the Pioneer wheels
         cs.set_joint_target_velocities({'PioneerP3DX/rightMotor'}, 0.1);
@@ -100,9 +103,17 @@ try
 
         % Trigger a simulation step in CoppeliaSim
         cs.trigger_next_simulation_step();    
+        
+
+        % Save data to compare the reference and read torques
+        torque_log(i+1) = torque;
+        torque_read_log(i+1) = torque_read;
     end
 
     cs.stop_simulation(); % Stop the simulation
+    plot(torque_log, 'b');
+    hold on
+    plot(torque_read_log, 'r')
 
 catch ME
 

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -40,10 +40,8 @@ cs = DQ_CoppeliaSimInterfaceZMQ();
 
 
 try
-    % Establish the connection with CoppeliaSim. If the simulation is running in the
-    % same machine of this script and you are using the default port (23000), 
-    % you can call connect() with no arguments.
-    cs.connect("localhost", 23000, 5000);
+    % Establish the connection with CoppeliaSim. 
+    cs.connect();
 
     % Set the stepping mode. 
     % Check more in https://manual.coppeliarobotics.com/en/simulation.htm

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -50,7 +50,7 @@ try
     % Starts the simulation. 
     cs.start_simulation();
 
-    % Define 
+    % Define some parameters to compute vayring-time trajectories
     a = 1;
     freq = 0.1;
     time_simulation_step = 0.05;

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -91,7 +91,7 @@ try
 
         % Set the torque of the fifth joint of the Franka Emika Panda
         torque = sin(2*pi*freq*t);
-        cs.set_joint_target_velocities({'Franka/link5_resp/joint'}, torque);
+        cs.set_joint_torques({'Franka/link5_resp/joint'}, torque);
 
         % Set the target velocities of the Pioneer wheels
         cs.set_joint_target_velocities({'PioneerP3DX/rightMotor'}, 0.1);
@@ -106,7 +106,7 @@ try
 
 catch ME
 
-    %cs.stop_simulation(); % Stop the simulation
+    cs.stop_simulation(); % Stop the simulation
     rethrow(ME)
 
 end

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -43,7 +43,7 @@ try
     % Establish the connection with CoppeliaSim. If the simulation is running in the
     % same machine of this script and you are using the default port (23000), 
     % you can call connect() with no arguments.
-    cs.connect();
+    cs.connect("localhost", 23000, 5000);
 
     % Set the stepping mode. 
     % Check more in https://manual.coppeliarobotics.com/en/simulation.htm
@@ -57,7 +57,7 @@ try
     freq = 0.1;
     time_simulation_step = 0.05;
 
-    for i=0:500
+    for i=0:300
         t = i*time_simulation_step;
 
         % Define a varying-time position based on the Lemniscate of Bernoulli
@@ -108,7 +108,8 @@ try
 
 catch ME
 
-    cs.stop_simulation(); % Stop the simulation
+    %cs.stop_simulation(); % Stop the simulation
     rethrow(ME)
 
 end
+

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -1,6 +1,11 @@
 % This example shows how to use basic commands in CoppeliaSim.
+%
+% Note:
+%
+% Open the DQ_Robotics_lab.ttt scene (https://github.com/dqrobotics/coppeliasim-scenes) 
+% in CoppeliaSim before running this script.
 % 
-% (C) Copyright 2025 DQ Robotics Developers
+% (C) Copyright 2011-2025 DQ Robotics Developers
 % 
 % This file is part of DQ Robotics.
 % 
@@ -17,16 +22,13 @@
 %     You should have received a copy of the GNU Lesser General Public License
 %     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 %
-% DQ Robotics website: dqrobotics.sourceforge.net
+% DQ Robotics website: https://dqrobotics.github.io/
 %
 % Contributors to this file:
 %    1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
-%
-%
-% Note:
-%
-% Open the DQ_Robotics_lab.ttt scene (https://github.com/dqrobotics/coppeliasim-scenes) 
-% in CoppeliaSim before running this script.
+
+
+
 
 
 clear;

--- a/coppeliasim/general/basic_commands.m
+++ b/coppeliasim/general/basic_commands.m
@@ -1,0 +1,114 @@
+% This example shows how to use basic commands in CoppeliaSim.
+% 
+% (C) Copyright 2025 DQ Robotics Developers
+% 
+% This file is part of DQ Robotics.
+% 
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published by
+%     the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+% 
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+% 
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+%
+% DQ Robotics website: dqrobotics.sourceforge.net
+%
+% Contributors to this file:
+%    1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+%
+%
+% Note:
+%
+% Open the DQ_Robotics_lab.ttt scene in CoppeliaSim before running this
+% script.
+
+
+clear;
+close all;
+clc;
+
+include_namespace_dq;
+
+% Instantiate the class
+cs = DQ_CoppeliaSimInterfaceZMQ();
+
+
+try
+    % Establish the connection with CoppeliaSim. If the simulation is running in the
+    % same machine of this script and you are using the default port (23000), 
+    % you can call connect() with no arguments.
+    cs.connect();
+
+    % Set the stepping mode. 
+    % Check more in https://manual.coppeliarobotics.com/en/simulation.htm
+    cs.set_stepping_mode(true);
+
+    % Starts the simulation. 
+    cs.start_simulation();
+
+    % Define 
+    a = 1;
+    freq = 0.1;
+    time_simulation_step = 0.05;
+
+    for i=0:500
+        t = i*time_simulation_step;
+
+        % Define a varying-time position based on the Lemniscate of Bernoulli
+        p = (a*cos(t)/(1 + (sin(t)^2)))*i_ + (a*sin(t)*cos(t)/(1 + (sin(t)^2)))*j_;
+
+        % Define a varying-time orientation
+        r = cos(2*pi*freq*t) + k_*sin(2*pi*freq*t);
+
+        % Built a varying-time unit dual quaternion
+        x = r + 0.5*E_*p*r;
+
+        % Set the object pose in CoppeliaSim
+        cs.set_object_pose("/coffee_drone", x);
+
+        % Read the pose of an object in CoppeliaSim to set the pose of
+        % another object with a constant offset.
+        xread = cs.get_object_pose("/coffee_drone");
+        xoffset = 1 + 0.5*E_*(0.5*i_);
+        xnew = xread*xoffset;
+        cs.set_object_pose("/Frame_x", xnew);
+
+
+        % Set the target position of the first joint of the UMIRobot arm
+        target_position = sin(2*pi*freq*t);
+        cs.set_joint_target_positions({'UMIRobot/UMIRobot_joint_1'}, target_position);
+
+        % Set the target position of the third joint of the UR5 robot
+        cs.set_joint_target_positions({'UR5/link/joint/link/joint'}, target_position);
+
+        % Set the target velocity of the first joint of the Franka Emika Panda
+        target_velocity = 2*pi*freq*cos(2*pi*freq*t);
+        cs.set_joint_target_velocities({'Franka/joint'}, target_velocity);
+
+        % Set the torque of the fifth joint of the Franka Emika Panda
+        torque = sin(2*pi*freq*t);
+        cs.set_joint_target_velocities({'Franka/link5_resp/joint'}, torque);
+
+        % Set the target velocities of the Pioneer wheels
+        cs.set_joint_target_velocities({'PioneerP3DX/rightMotor'}, 0.1);
+        cs.set_joint_target_velocities({'PioneerP3DX/leftMotor'}, 0.2);
+
+
+        % Trigger a simulation step in CoppeliaSim
+        cs.trigger_next_simulation_step();    
+    end
+
+    cs.stop_simulation(); % Stop the simulation
+
+catch ME
+
+    cs.stop_simulation(); % Stop the simulation
+    rethrow(ME)
+
+end

--- a/coppeliasim/general/stepping_mode_test.m
+++ b/coppeliasim/general/stepping_mode_test.m
@@ -23,6 +23,12 @@
 %
 % Contributors to this file:
 %    1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+%
+%
+% Note:
+%
+% Open the DQ_Robotics_lab.ttt scene in CoppeliaSim before running this
+% script.
 
 clear;
 close all;

--- a/coppeliasim/general/stepping_mode_test.m
+++ b/coppeliasim/general/stepping_mode_test.m
@@ -1,0 +1,80 @@
+% This example shows how to use the stepping mode.
+% The example performs a free fall test of an object and shows the 
+% estimated and measured height of the object after some seconds.
+% 
+% (C) Copyright 2025 DQ Robotics Developers
+% 
+% This file is part of DQ Robotics.
+% 
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published by
+%     the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+% 
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+% 
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+%
+% DQ Robotics website: dqrobotics.sourceforge.net
+%
+% Contributors to this file:
+%    1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+
+clear;
+close all;
+clc;
+
+
+% Instantiate the class
+cs = DQ_CoppeliaSimInterfaceZMQ();
+
+
+try
+    % Establish the connection with CoppeliaSim. If the simulation is running in the
+    % same machine of this script, you can use "localhost". Furthermore, we
+    % use the default port 23000.
+    cs.connect("localhost", 23000);
+
+    % Set the stepping mode. 
+    % Check more in https://manual.coppeliarobotics.com/en/simulation.htm
+    cs.set_stepping_mode(true);
+
+    % Starts the simulation. 
+    cs.start_simulation();
+
+    % Read the position [x y z] of the Sphere object in CoppeliaSim
+    p0 = vec3(cs.get_object_translation('/Sphere'));
+    y0 = p0(3); % Height of the object.
+
+    % Define the simulation time step to match the simulation dt in
+    % CoppeliaSim. 
+    % Check more in https://manual.coppeliarobotics.com/en/simulationPropertiesDialog.htm#:~:text=Simulation%20dt%3A%20the%20simulation%20time,dynamics%20dt%20(see%20below).
+    time_simulation_step = 0.05;
+    gravity = -9.81;
+    disp('---------------------------------')
+    disp(['Initial height: ',num2str(y0)])
+    disp('---------------------------------')
+
+    for i=0:4
+        t = i*time_simulation_step;
+        p = vec3(translation(cs.get_object_pose('/Sphere')));
+        y_sim = p(3);
+        y_est = y0 - 0.5*gravity*t^2; 
+
+        % Trigger a simulation step in CoppeliaSim
+        cs.trigger_next_simulation_step();
+    end
+    disp(['Elapsed time: ',num2str(t)])
+    disp(['Estimated height: ',num2str(y_est),'. Measured height: ', num2str(y_sim)])
+    cs.stop_simulation(); % Stop the simulation
+
+catch ME
+
+    cs.stop_simulation(); % Stop the simulation
+    rethrow(ME)
+
+end

--- a/coppeliasim/general/stepping_mode_test.m
+++ b/coppeliasim/general/stepping_mode_test.m
@@ -1,8 +1,11 @@
 % This example shows how to use the stepping mode.
-% The example performs a free fall test of an object and shows the 
-% estimated and measured height of the object after some seconds.
+%
+% Note:
+%
+% Open the DQ_Robotics_lab.ttt scene (https://github.com/dqrobotics/coppeliasim-scenes) 
+% in CoppeliaSim before running this script.
 % 
-% (C) Copyright 2025 DQ Robotics Developers
+% (C) Copyright 2011-2025 DQ Robotics Developers
 % 
 % This file is part of DQ Robotics.
 % 
@@ -19,16 +22,10 @@
 %     You should have received a copy of the GNU Lesser General Public License
 %     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 %
-% DQ Robotics website: dqrobotics.sourceforge.net
+% DQ Robotics website: https://dqrobotics.github.io/
 %
 % Contributors to this file:
 %    1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
-%
-%
-% Note:
-%
-% Open the DQ_Robotics_lab.ttt scene in CoppeliaSim before running this
-% script.
 
 clear;
 close all;
@@ -61,22 +58,27 @@ try
     % Check more in https://manual.coppeliarobotics.com/en/simulationPropertiesDialog.htm#:~:text=Simulation%20dt%3A%20the%20simulation%20time,dynamics%20dt%20(see%20below).
     time_simulation_step = 0.05;
     gravity = -9.81;
-    disp('---------------------------------')
-    disp(['Initial height: ',num2str(y0)])
-    disp('---------------------------------')
 
     for i=0:4
-        t = i*time_simulation_step;
+        t(i+1) = i*time_simulation_step;
+
+        % Height measurement. We obtain the position of the object, 
+        % and extract the z-axis coordinate.
         p = vec3(translation(cs.get_object_pose('/Sphere')));
-        y_sim = p(3);
-        y_est = y0 - 0.5*gravity*t^2; 
+        y_sim(i+1) = p(3);
+
+        % Height estimatation based on the free falling motion
+        y_est(i+1) = y0 + 0.5*gravity*t(i+1)^2; 
+
+        error(i+1) = norm(y_sim(i+1)-y_est(i+1));
 
         % Trigger a simulation step in CoppeliaSim
         cs.trigger_next_simulation_step();
     end
-    disp(['Elapsed time: ',num2str(t)])
-    disp(['Estimated height: ',num2str(y_est),'. Measured height: ', num2str(y_sim)])
     cs.stop_simulation(); % Stop the simulation
+
+    % Display the results on the Commmand Window
+    T = table(t', y_est', y_sim', error', 'VariableNames', {'t(s)', 'Estimated height', 'Measured height', 'error'})
 
 catch ME
 


### PR DESCRIPTION
Hi @dqrobotics/developers 

This PR adds two examples to test all new methods implemented in the `DQ_CoppeliaSimInterfaceZMQ` class. Furthermore,  I propose a new scene containing different objects and robots, which could be compatible with several future examples. The scene is called `DQ_Robotics_lab.ttt`.

![dqlab](https://github.com/user-attachments/assets/3e59e24b-c883-41e3-943f-860395b4ac12)

Kind regards, 

Juancho
